### PR TITLE
Offset issue cause of downloading fewer photos than expected

### DIFF
--- a/sources/vk/vk.go
+++ b/sources/vk/vk.go
@@ -123,7 +123,7 @@ func (v *Vk) AlbumPhotos(albumID string) (sources.ItemFetcher, error) {
 	}
 	var resp api.PhotosGetResponse
 	items := make([]object.PhotosPhoto, 0, albumResp.Count)
-	for offset := 1; offset <= albumResp.Count; offset += maxCount {
+	for offset := 0; offset <= albumResp.Count; offset += maxCount {
 		resp, err = v.vkAPI.PhotosGet(api.Params{"album_id": albumID, "count": maxCount, "photo_sizes": 1, "offset": offset})
 		if err != nil {
 			log.Println("DownloadAlbum:", err)


### PR DESCRIPTION
The offset is initialized to 1 instead of 0. The VK API's offset parameter is zero-based, meaning the first page of results starts at an offset of 0. Starting at 1 skips the first maxCount number of photos. 

Offset issue cause of downloading fewer photos than expected